### PR TITLE
fixed bug where odd numbers might return None

### DIFF
--- a/prime_number_sum.py
+++ b/prime_number_sum.py
@@ -23,7 +23,7 @@ def is_prime(num):
     return True
 
 
-# Method to find the prime numbers that sum up to the given number
+# Method to find the prime numbers that sum up to the given number (odd numbers with no primes will return None)
 def primesum(A):
     # Only need to check till A/2 because the complement is already checked in the first half of the range
     # e.g. if number is 25, then (2 + 23) == (23 + 2), i.e you've already check out 23 once
@@ -31,5 +31,7 @@ def primesum(A):
         if (is_prime(i) and is_prime(A - i)):
             return (i, A - i)
 
+    return None
+
 # Main
-print(primesum(9))
+print(primesum(100299392))


### PR DESCRIPTION
The problem states it need to only check for even integers greater than 2. But we need to handle odd integers gracefully (some odd integers can be sum of 2 primes, but not all). Handled this case by returning None if primes are not found.